### PR TITLE
Fixed WordPress hook callback functions should be in snake_case.

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -29,6 +29,13 @@
 
     <!-- Custom exclusions. -->
     <exclude name="Drupal.Commenting.InlineComment.DocBlock"/>
+    <!-- Our guideline is to use the hook name as method name, in snake_case.
+         The exception to this can be cases in which the same callback is
+         registered for multiple hooks (potentially even having different
+         signatures). In that case, a custom method name can describe the method
+         better, but this is not a must and depends on the situation. A custom
+         method name uses camelCase. Also to indicate that it is not referring
+         to a hook name. -->
     <exclude name="Drupal.NamingConventions.ValidFunctionName"/>
   </rule>
   <rule ref="Drupal.Commenting.FunctionComment">

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -29,6 +29,7 @@
 
     <!-- Custom exclusions. -->
     <exclude name="Drupal.Commenting.InlineComment.DocBlock"/>
+    <exclude name="Drupal.NamingConventions.ValidFunctionName"/>
   </rule>
   <rule ref="Drupal.Commenting.FunctionComment">
     <exclude name="Drupal.Commenting.FunctionComment.TypeHintMissing"/>


### PR DESCRIPTION
Problem
- phpcs complains when defining class functions in snake_case.

Details
- Our guideline is to name WordPress hook callbacks after the name of the hook that they are implementing; i.e., in snake_case.

Context
- https://netzstrategen.slack.com/archives/CAKR4RGBY/p1642520539010400